### PR TITLE
Write the GitLab artifacts to temporary ZIP files

### DIFF
--- a/src/main/java/com/microfocus/octane/gitlab/helpers/StreamHelper.java
+++ b/src/main/java/com/microfocus/octane/gitlab/helpers/StreamHelper.java
@@ -1,0 +1,27 @@
+package com.microfocus.octane.gitlab.helpers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class StreamHelper {
+
+    private StreamHelper() {
+    }
+
+    public static void copyStream(InputStream is, OutputStream os) throws IOException {
+        if (is == null) {
+            return;
+        }
+
+        byte[] buf = new byte[4096];
+        int n;
+
+        while ((n = is.read(buf, 0, 4096)) > 0) {
+            os.write(buf, 0, n);
+        }
+
+        os.flush();
+    }
+
+}


### PR DESCRIPTION
GitLab creates ZIP artifacts that can't be processed directly from the input stream. Stream processing leads to a ZipException (only DEFLATED entries can have EXT descriptor).

This PR changes the artifact download to use a temporary ZIP file.