### PR TITLE
Honour nonProxyHosts setting when connecting to GitLab

### DIFF
--- a/src/main/java/com/microfocus/octane/gitlab/helpers/GitLabApiWrapper.java
+++ b/src/main/java/com/microfocus/octane/gitlab/helpers/GitLabApiWrapper.java
@@ -1,5 +1,6 @@
 package com.microfocus.octane.gitlab.helpers;
 
+import com.hp.octane.integrations.util.CIPluginSDKUtils;
 import com.microfocus.octane.gitlab.app.ApplicationSettings;
 import com.microfocus.octane.gitlab.model.ConfigStructure;
 import org.gitlab4j.api.GitLabApi;
@@ -33,9 +34,11 @@ public class GitLabApiWrapper {
     public void initGitlabApiWrapper() throws MalformedURLException, GitLabApiException, ConfigurationException {
         ConfigStructure config = applicationSettings.getConfig();
         Map<String, Object> proxyConfig = null;
-        String protocol = new URL(config.getGitlabLocation()).getProtocol().toLowerCase();
-        String proxyUrl = config.getProxyField(protocol, "proxyUrl");
-        if (proxyUrl != null) {
+        URL targetUrl = CIPluginSDKUtils.parseURL(config.getGitlabLocation());
+
+        if (ProxyHelper.isProxyNeeded(applicationSettings, targetUrl)) {
+            String protocol = targetUrl.getProtocol().toLowerCase();
+            String proxyUrl = config.getProxyField(protocol, "proxyUrl");
             String proxyPassword = config.getProxyField(protocol, "proxyPassword");
             if (proxyPassword != null && proxyPassword.startsWith(PREFIX)) {
                 try {

--- a/src/main/java/com/microfocus/octane/gitlab/helpers/ProxyHelper.java
+++ b/src/main/java/com/microfocus/octane/gitlab/helpers/ProxyHelper.java
@@ -1,0 +1,24 @@
+package com.microfocus.octane.gitlab.helpers;
+
+import com.hp.octane.integrations.util.CIPluginSDKUtils;
+import com.microfocus.octane.gitlab.app.ApplicationSettings;
+import com.microfocus.octane.gitlab.model.ConfigStructure;
+
+import java.net.URL;
+
+public class ProxyHelper {
+
+    public static boolean isProxyNeeded(ApplicationSettings applicationSettings, URL targetHost) {
+        if (targetHost == null) return false;
+        boolean result = false;
+        ConfigStructure config = applicationSettings.getConfig();
+        if (config.getProxyField(targetHost.getProtocol(), "proxyUrl") != null) {
+            String nonProxyHostsStr = config.getProxyField(targetHost.getProtocol(), "nonProxyHosts");
+            if (!CIPluginSDKUtils.isNonProxyHost(targetHost.getHost(), nonProxyHostsStr)) {
+                result = true;
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/com/microfocus/octane/gitlab/services/OctaneServices.java
+++ b/src/main/java/com/microfocus/octane/gitlab/services/OctaneServices.java
@@ -16,6 +16,7 @@ import com.microfocus.octane.gitlab.app.ApplicationSettings;
 import com.microfocus.octane.gitlab.helpers.GitLabApiWrapper;
 import com.microfocus.octane.gitlab.helpers.Pair;
 import com.microfocus.octane.gitlab.helpers.PasswordEncryption;
+import com.microfocus.octane.gitlab.helpers.ProxyHelper;
 import com.microfocus.octane.gitlab.model.ConfigStructure;
 import com.microfocus.octane.gitlab.model.junit5.Testcase;
 import com.microfocus.octane.gitlab.model.junit5.Testsuite;
@@ -141,7 +142,7 @@ public class OctaneServices extends CIPluginServicesBase {
     public CIProxyConfiguration getProxyConfiguration(URL targetUrl) {
         try {
             CIProxyConfiguration result = null;
-            if (isProxyNeeded(targetUrl)) {
+            if (ProxyHelper.isProxyNeeded(applicationSettings, targetUrl)) {
                 ConfigStructure config = applicationSettings.getConfig();
                 log.info("proxy is required for host " + targetUrl);
                 String protocol = targetUrl.getProtocol();
@@ -355,16 +356,4 @@ public class OctaneServices extends CIPluginServicesBase {
         result.add(tr);
     }
 
-    private boolean isProxyNeeded(URL targetHost) {
-        if (targetHost == null) return false;
-        boolean result = false;
-        ConfigStructure config = applicationSettings.getConfig();
-        if (config.getProxyField(targetHost.getProtocol(), "proxyUrl") != null) {
-            String nonProxyHostsStr = config.getProxyField(targetHost.getProtocol(), "nonProxyHosts");
-            if (!CIPluginSDKUtils.isNonProxyHost(targetHost.getHost(), nonProxyHostsStr)) {
-                result = true;
-            }
-        }
-        return result;
-    }
 }


### PR DESCRIPTION
If a proxy is configured the GitLab connection always uses it even if the GitLab host is excluded in _nonProxyHosts_. This prevents us from using a proxy for the octane connection but not for GitLab.

This PR changes this to use the same method to determine whether to use a proxy for both connections. 