### PR TITLE
defect #1089556: [GitLab] Running projects from another member can be…

### DIFF
--- a/src/main/java/com/microfocus/octane/gitlab/api/EventListener.java
+++ b/src/main/java/com/microfocus/octane/gitlab/api/EventListener.java
@@ -87,7 +87,7 @@ public class EventListener {
                         ParsedPath parsedPath = new ParsedPath(event.getProject(), gitLabApi, PathType.PIPELINE);
                         if (parsedPath.isMultiBranch()) {
                             event.setProjectDisplayName(parsedPath.getFullPathOfProjectWithBranch());
-                            event.setParentCiId(parsedPath.getFullPathOfPipeline()).setMultiBranchType(MultiBranchType.MULTI_BRANCH_CHILD);
+                            event.setParentCiId(parsedPath.getFullPathOfPipeline().toLowerCase()).setMultiBranchType(MultiBranchType.MULTI_BRANCH_CHILD);
                         }
                     }
                 } else if (eventType == CIEventType.DELETED) {


### PR DESCRIPTION
… added twice after a run