### PR TITLE
us #1510035: change return value in case when duration is null

### DIFF
--- a/src/main/java/com/microfocus/octane/gitlab/api/EventListener.java
+++ b/src/main/java/com/microfocus/octane/gitlab/api/EventListener.java
@@ -343,7 +343,7 @@ public class EventListener {
     }
 
     private Long calculateDuration(CIEventType eventType, Object duration) {
-        if(eventType == CIEventType.STARTED || duration == null) return null;
+        if(eventType == CIEventType.STARTED || duration == null) return 0L;
 
         if(duration instanceof Double) return Math.round(1000* (Double) duration);
         if(duration instanceof BigDecimal) return Long.valueOf(Math.round(1000* ((BigDecimal) duration).intValue()));


### PR DESCRIPTION
We need to change this value to get correct information about duration time. 
There are some troubles when we are trying to abort Pipeline run that is in pending phase
After this change everything works properly for us